### PR TITLE
Fix LanguageSelector view. Make sure redirectid always has a value.

### DIFF
--- a/webapp-net/Core/Areas/Core/Views/Entity/LanguageSelector.cshtml
+++ b/webapp-net/Core/Areas/Core/Views/Entity/LanguageSelector.cshtml
@@ -12,7 +12,11 @@
 
         filteredLocalizations.AddRange(siteLocalizations.Where(siteLoc => !excludedLocalizations.Contains(siteLoc.Path)).Select(s=>s));
     }
-    var redirectId = WebRequestContext.PageModel.Id;
+    var redirectId = "0";
+    if (WebRequestContext.PageModel != null && !string.IsNullOrEmpty(WebRequestContext.PageModel.Id))
+    {
+        redirectId = WebRequestContext.PageModel.Id;
+    }
     var defaultItem = Model.Settings.ContainsKey("defaultContentLink") ? Model.Settings["defaultContentLink"] : null;
 }
 @if (redirectId != null && filteredLocalizations.Count > 1)


### PR DESCRIPTION
The language selector view in the core module does an assumption that there always is a PageModel object in the WebRequestContext. This is not always the case, for example when browsing through product pages in the E-Commerce framework.

This PR checks if the `WebRequestContext.PageModel.Id` is set properly, and defaults the redirectId to 0. 0 is a good default for the redirect mechanism, it will not find a page with id 0 and serve the fallback page, or ultimately the home page.

This fixes issue https://github.com/sdl/dxa-modules/issues/24

